### PR TITLE
Pass in state and options to the validators

### DIFF
--- a/lib/extender.js
+++ b/lib/extender.js
@@ -14,8 +14,8 @@ var util = require('util'),
     _ = require('lodash'),
     hoek = require('hoek'),
     joi = require('joi'),
-    Any = require(path.join(__dirname, '../node_modules/joi/lib/any')),
-    Errors = require(path.join(__dirname, '../node_modules/joi/lib/errors'));
+    Any = require('joi/lib/any'),
+    Errors = require('joi/lib/errors');
 
 /**
  * @module joiExtender
@@ -102,7 +102,7 @@ var typeFactory = function (type, opts) {
         if (!_.isFunction(fn)) {
           throw new Error('requirement "' + name + '" requires a function');
         }
-        if (!fn.call(this, value)) {
+        if (!fn.call(this, value, state, options)) {
           err = Errors.create(type + '.' + name, null, state, options);
           break;
         }
@@ -124,7 +124,7 @@ var typeFactory = function (type, opts) {
         var args = _.flatten(arguments);
         return this._test(key, args, function (value, state, options) {
           options.language = _.merge(errmsgs, options.language);
-          var result = fn(value, args);
+          var result = fn(value, args, state, options);
           return result ? Errors.create(type + '.' + result, {args: args}, state, options) : null;
         });
       };

--- a/test/extender.js
+++ b/test/extender.js
@@ -17,6 +17,9 @@ var util = require('util'),
     extender = require(path.join(__dirname, '../lib/extender')),
     is_dma = require('is_dma');
 
+var requirementsArguments = null,
+    testsArguments = null;
+
 chai.should(); // side effect!!: extends Object.prototype
 
 require('./helpers/chai_extensions'); // side effect!!: extends chai
@@ -36,11 +39,15 @@ describe('extender', function () {
         badFoo: 'is not foo-worthy'
       },
       requirements: {
-        base: function (value) { return _.isString(value) },
+        base: function (value) {
+          requirementsArguments = arguments;
+          return _.isString(value)
+        },
         invalid: function (value) { return is_dma(value) }
       },
       tests: {
         isFoo: function (value, args) {
+          testsArguments = arguments;
           if ('502' === value) return 'badFoo';
         }
       }
@@ -83,6 +90,13 @@ describe('extender', function () {
     var result = joi.dma().required().isFoo().label('dma').validate('502');
     //console.log(util.inspect(result,{depth:null}));
     result.should.have.errmsg('"dma" is not foo-worthy');
+  });
+
+  it('should have passed value, state, and options to requirements functions', function () {
+    requirementsArguments.should.have.length(3);
+    requirementsArguments[0].should.equal('502');
+    requirementsArguments[1].should.have.property('key');
+    requirementsArguments[2].should.have.property('abortEarly');
   });
 
 });

--- a/test/extender.js
+++ b/test/extender.js
@@ -36,8 +36,8 @@ describe('extender', function () {
         badFoo: 'is not foo-worthy'
       },
       requirements: {
-        base: _.isString,
-        invalid: is_dma
+        base: function (value) { return _.isString(value) },
+        invalid: function (value) { return is_dma(value) }
       },
       tests: {
         isFoo: function (value, args) {


### PR DESCRIPTION
This change was introduced to allow a "requiredUnless" validator. For example, "Home phone" is required unless "Mobile phone" is filled. As such, it needed access to the state.

```
extender.addValidator('customValidators', {
    tests: {
        requiredUnless: function (value, args, state) {
            var key = args[0];
            var otherValue = (state.parent[key] || '').toString();
            return (otherValue === '' && value === '') ? 'requiredUnless' : null;
        }
    },
    errmsgs: {
        requiredUnless: 'is required unless another field is filled'
    }
});
```

This commit also fixes the require paths for Webpack/browserify support rather than using relative paths.
