### PR TITLE
Fix: path to main file in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "joi-extender",
   "version": "0.2.6",
   "description": "Extends Joi with new top-level validations and chain-ables.",
-  "main": "index.js",
+  "main": "./lib/extender.js",
   "directories": {
     "doc": "./doc",
     "lib": "./lib",


### PR DESCRIPTION
Without this fix running this:

```
npm install joi-extender
echo "require('joi-extender')" > smoke.js
node smoke.js
```

results in:

```

module.js:340
    throw err;
          ^
Error: Cannot find module 'joi-extender'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/Users/urukhai/Job/nu/util/js/api-master/smoke.js:1:63)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)
```
